### PR TITLE
"Select * from math order by id,grade;" works.

### DIFF
--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -269,24 +269,6 @@ unique_ptr<Expression> PhysicalOperator::ExpressionPassThrough(const PhysicalOpe
 COrderProperty::EPropEnforcingType PhysicalOperator::EnforcingTypeOrder(CExpressionHandle &handle,
                                                                         vector<BoundOrderByNode> &peo) const {
 	if (handle.group_expr() != nullptr) {
-		// It is very dangerous here.
-//		if (physical_type == PhysicalOperatorType::PROJECTION) {
-//			vector<BoundOrderByNode> v;
-//			size_t proj_table_idx = ((PhysicalProjection *)this)->v_column_binding[0].table_index;
-//			for (auto &node : peo) {
-//				auto *bound_expr = (BoundColumnRefExpression *)node.expression.get();
-//				size_t node_table_idx = bound_expr->GetColumnBinding()[0].table_index;
-//				if (node_table_idx == proj_table_idx) {
-//					v.push_back(node);
-//				}
-//			}
-//			if (v.empty())
-//				return COrderProperty::EPropEnforcingType::EpetUnnecessary;
-//			else {
-//				return COrderProperty::EPropEnforcingType::EpetRequired;
-//			}
-//		}
-
 		vector<BoundOrderByNode> v;
 		/* In case inconsistence */
 		for (auto &child : peo) {

--- a/src/optimizer/cascade/base/COrderSpec.cpp
+++ b/src/optimizer/cascade/base/COrderSpec.cpp
@@ -45,7 +45,7 @@ COrderSpec::~COrderSpec() {
 //
 //---------------------------------------------------------------------------
 void COrderSpec::Append(OrderType type, OrderByNullType null_order, Expression *expr) {
-	order_nodes.emplace_back(type, null_order, duckdb::unique_ptr<Expression>(expr));
+	order_nodes.emplace_back(type, null_order, expr->Copy());
 }
 
 //---------------------------------------------------------------------------

--- a/src/optimizer/cascade/base/CQueryContext.cpp
+++ b/src/optimizer/cascade/base/CQueryContext.cpp
@@ -90,12 +90,12 @@ CQueryContext *CQueryContext::QueryContextGenerate(duckdb::unique_ptr<Operator> 
 			spec->order_nodes.emplace_back(child.type, child.null_order, child.expression->Copy());
 		expr = std::move(expr->children[0]);
 	}
-//	for (size_t i = 0; i < expr->children.size(); i++)
-//		RemoveOrderBy(spec, expr.get(), expr->children[i].get(), i);
+	//	for (size_t i = 0; i < expr->children.size(); i++)
+	//		RemoveOrderBy(spec, expr.get(), expr->children[i].get(), i);
+	//  Printer::Print("Logical Plan Without OrderBy\n");
+	//	((LogicalOperator *)expr.get())->Print();
 
 	// construct the physical property
-	Printer::Print("Logical Plan Without OrderBy\n");
-	((LogicalOperator *)expr.get())->Print();
 	COrderProperty *order_property = new COrderProperty(spec, COrderProperty::EomSatisfy);
 	CRequiredPhysicalProp *physical_property = new CRequiredPhysicalProp(required_cols, order_property);
 


### PR DESCRIPTION
Now, orderby (maybe) has been finished.

But, current orderbys are not fully optimized by cascade: they cannot be moved around. This topic can be ignored currently, since our focus is the join order.